### PR TITLE
Added info on 2011 school

### DIFF
--- a/2011.md
+++ b/2011.md
@@ -1,0 +1,10 @@
+---
+title: LANL Co-Design Summer School - Class of 2011
+layout: page
+---
+# Class of 2011
+
+Han Dong (SUNY Buffalo), Mahesh Ravishankar (Ohio State), Paul Sathre (Virginia
+State),Michael Sullivan (U. Texas Austin), William Taitano (University of New
+Mexico), Jeffery Willert (North Carolina State)
+

--- a/history.md
+++ b/history.md
@@ -15,6 +15,8 @@ layout: page
 
 ### [Class of 2012: Scale Bridging Approach to a Steady-state Neutron Transport](2012.html)
 
+### [Class of 2011: Quasi Diffusion Accelerated Monte Carlo](2011.html)
+
 # Founder
 ![](images/al-1.jpg)
 


### PR DESCRIPTION
I haven't been able to find an image of the 2011 school. I do have an extensive movie, but would have to find the LA-UR for it. I also have their final report (ditto the LA-UR issue). Their code is at `https://github.com/lanl/HILO`.

Obviously, I didn't test these additions.

Fix #1 .